### PR TITLE
Create/update datasources in BOSH post-start script

### DIFF
--- a/jobs/grafana/monit
+++ b/jobs/grafana/monit
@@ -3,5 +3,3 @@ check process grafana
   start program "/var/vcap/jobs/grafana/bin/grafana_ctl start"
   stop program "/var/vcap/jobs/grafana/bin/grafana_ctl stop"
   group vcap
-check file datasource_marker with path /var/vcap/sys/run/grafana/datasource_created
-  if does not exist then exec /var/vcap/jobs/grafana/bin/create_datasource

--- a/jobs/grafana/spec
+++ b/jobs/grafana/spec
@@ -3,8 +3,9 @@ name: grafana
 
 templates:
   grafana_ctl: bin/grafana_ctl
+  post-start: bin/post-start
   create_dashboards.erb: bin/create_dashboards
-  create_datasource.erb: bin/create_datasource
+  create-update-datasources.erb: bin/create-update-datasources
   config.ini.erb: config/config.ini
   ssl.key.erb: config/ssl.key
   ssl.crt.erb: config/ssl.crt

--- a/jobs/grafana/templates/create-update-datasources.erb
+++ b/jobs/grafana/templates/create-update-datasources.erb
@@ -1,13 +1,38 @@
 #!/bin/bash
 
 LOG_DIR=/var/vcap/sys/log/grafana
-MARKERFILE=/var/vcap/sys/run/grafana/datasource_created
 
 <% p("grafana.datasources", []).each do |datasource| %>
 
-exec &>> ${LOG_DIR}/datasource_create.log
+exec &>> ${LOG_DIR}/create-update-datasources.log
+
 URL='<%= p("grafana.ssl.cert", nil) ? "https" : "http" %>://127.0.0.1:<%= p("grafana.listen_port") %>/api/datasources'
 CREDENTIALS='<%= p("grafana.admin_username") %>:<%= p("grafana.admin_password") %>'
+
+attempt=0
+exitCode=0
+while (( $attempt < 3 ))
+do
+  curl --connect-timeout 10 -u "${CREDENTIALS}" -ks "${URL}"
+  exitCode=$?
+  if [[ $exitCode == 0 ]]
+  then
+    break
+  fi
+
+  echo -e "\nCannot connect to Grafana. Retrying ..."
+  sleep 10
+  attempt=$(( attempt + 1 ))
+done
+if [[ $exitCode != 0 ]]
+then
+  echo -e "\nError: Cannot connect to Grafana after 3 retries."
+  exit 1
+fi
+
+<% datasources.each do |datasource| %>
+echo -e "\nCreating/Updating datasource '<%= datasource['name'] %>' at $(date)"
+
 DATASOURCE_NAME='<%= datasource['name'] %>'
 
 DATA='
@@ -24,16 +49,20 @@ DATA='
 # If we had jq, this is what the query would look like:
 #DATASOURCE_ID=$(curl -u "${CREDENTIALS}" -ks "${URL}" | jq '.[] | select(.name == "'"${DATASOURCE_NAME}"'") | .id ')
 # Instead we have to call sed to the rescue:
-DATASOURCE_ID=$(curl -u "${CREDENTIALS}" -ks "${URL}" | sed -n 's/[^"]*"id":\([0-9]*\),.*"name":"'"${DATASOURCE_NAME}"'".*$/\1/p' )
+DATASOURCE_ID=$(curl -u "${CREDENTIALS}" -ks "${URL}" | sed -n 's/^.*"id":\([0-9]*\)[^}]*"name":"'${DATASOURCE_NAME}'".*$/\1/p' )
 echo "Datasource '${DATASOURCE_NAME}' has id '${DATASOURCE_ID}'"
 
 if [ -n "${DATASOURCE_ID}" ]; then
   if curl -u "${CREDENTIALS}" -kivf -X PUT "${URL}/${DATASOURCE_ID}" -H 'Content-Type: application/json' -d "${DATA}" ; then
-    echo "Updated datasource ${DATASOURCE_NAME} at $(date)" > ${MARKERFILE}
+    echo -e "\nUpdated datasource ${DATASOURCE_NAME} at $(date)"
   fi
 else
   if curl -u "${CREDENTIALS}" -kivf -X POST "${URL}" -H 'Content-Type: application/json' -d "${DATA}" ; then
-    echo "Created datasource ${DATASOURCE_NAME} at $(date)" > ${MARKERFILE}
+    echo -e "\nCreated datasource ${DATASOURCE_NAME} at $(date)"
   fi
 fi
+<% end #each iterator %>
+
+<% if datasources.empty? then %>
+echo "No automatic datasource creation requested"
 <% end %>

--- a/jobs/grafana/templates/grafana_ctl
+++ b/jobs/grafana/templates/grafana_ctl
@@ -24,7 +24,6 @@ case $1 in
     mkdir -p $PACKAGE_DIR/data/log
     chown vcap:vcap $PACKAGE_DIR/data/log
 
-    (sleep 30; exec chpst -u vcap:vcap /var/vcap/jobs/grafana/bin/create_dashboards)&
     exec chpst -u vcap:vcap $PACKAGE_DIR/bin/grafana-server \
       -config=/var/vcap/jobs/grafana/config/config.ini \
       -homepath=$PACKAGE_DIR \

--- a/jobs/grafana/templates/post-start
+++ b/jobs/grafana/templates/post-start
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+echo "[$(date)] Calling 'create-update-datasources' ..."
+$(dirname $0)/create-update-datasources


### PR DESCRIPTION
- always create/update datasource configuration, not just during the first Grafana startup
- fix sed regex so that ids are correctly extracted if there are multiple datasources
- make sure Grafana can be connected (retry a few times)

Cherry-picked from https://github.com/vito/grafana-boshrelease/commit/9ca765729f41c64f857aad6d4c04a04812cc192d so that datasources are created on update.

@sharms
